### PR TITLE
Add __main__ entrypoint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -125,7 +125,8 @@ For the full list:
 ```
 sam2_masking/           # installable Python package
   ├─ core.py            # processing logic
-  └─ cli.py             # entry‑point (python -m sam2_masking)
+  ├─ cli.py             # CLI helpers
+  └─ __main__.py        # entry point for `python -m sam2_masking`
 
 sam2/                   # full SAMURAI repo (includes the sam2 package)
 checkpoints/            # large .pt weight files – ignored by git

--- a/sam2_masking/__main__.py
+++ b/sam2_masking/__main__.py
@@ -1,0 +1,7 @@
+import sys
+import torch
+from .cli import main
+
+if __name__ == "__main__":
+    torch.multiprocessing.set_start_method("spawn", force=True)
+    sys.exit(main())

--- a/sam2_masking/cli.py
+++ b/sam2_masking/cli.py
@@ -62,4 +62,3 @@ def main():
 if __name__ == "__main__":
     torch.multiprocessing.set_start_method("spawn", force=True)
     sys.exit(main())
-cli.py


### PR DESCRIPTION
## Summary
- add `sam2_masking/__main__.py` so `python -m sam2_masking` works
- tweak README project structure description
- remove stray text from cli.py

## Testing
- `python -m sam2_masking --help | head` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688326e5ecec832784537b19d3dd45b5