### PR TITLE
Add device parameter to run_tracking

### DIFF
--- a/sam2_masking/cli.py
+++ b/sam2_masking/cli.py
@@ -52,7 +52,7 @@ def main():
     predictor = build_samurai(args.checkpoint, args.device)
 
     # 5. Tracking
-    masks = run_tracking(in_path, bbox, predictor, len(frames))
+    masks = run_tracking(in_path, bbox, predictor, len(frames), args.device)
 
     # 6. Export (original + masked + binary masks)
     save_processed(args.video, frames, masks)
@@ -62,4 +62,3 @@ def main():
 if __name__ == "__main__":
     torch.multiprocessing.set_start_method("spawn", force=True)
     sys.exit(main())
-cli.py


### PR DESCRIPTION
## Summary
- extend `run_tracking` to accept a `device` argument
- wrap `torch.autocast` only when running on CUDA
- pass device from CLI
- clean up stray line at end of `cli.py`

## Testing
- `python -m py_compile sam2_masking/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688326eb28888327bc046e83ea3d563f