### PR TITLE
Remove stray line from CLI

### DIFF
--- a/sam2_masking/cli.py
+++ b/sam2_masking/cli.py
@@ -62,4 +62,3 @@ def main():
 if __name__ == "__main__":
     torch.multiprocessing.set_start_method("spawn", force=True)
     sys.exit(main())
-cli.py


### PR DESCRIPTION
## Summary
- remove a stray `cli.py` line at the end of `sam2_masking/cli.py`

## Testing
- `python -m py_compile sam2_masking/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_688326ed992083278311da578a39f2c0