### PR TITLE
Fix license field in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sam2-masking"
 version = "0.1.0"
 description = "SAM-2 / SAMURAI video masking CLI"
 readme = "Readme.md"
-license = {file = "LICENSE"}
+license = "MIT"
 requires-python = ">=3.9"
 authors = [{name = "Oshane"}]
 


### PR DESCRIPTION
## Summary
- use SPDX license string instead of referencing the LICENSE file

## Testing
- `python -m pip install -e .` *(fails: multiple top-level packages discovered)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68832afad50c8327b2fdf7adcf547a21