### PR TITLE
Limit setuptools to sam2_masking package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ dependencies = [
 
 [project.scripts]
 sam2-masking = "sam2_masking.cli:main"
+
+[tool.setuptools]
+packages = ["sam2_masking"]


### PR DESCRIPTION
## Summary
- configure setuptools to package only the `sam2_masking` module

## Testing
- `pip install -e . --no-deps`

------
https://chatgpt.com/codex/tasks/task_e_68832d8102f88327b9874f8c6e0d230c