### PR TITLE
Add SAMURAI setup script

### DIFF
--- a/sam2/setup_samurai.sh
+++ b/sam2/setup_samurai.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SAM_REPO_DIR="$SCRIPT_DIR/sam2"
+
+# Clone SAMURAI repository if not present
+if [ ! -d "$SAM_REPO_DIR" ]; then
+    git clone https://github.com/yangchris11/samurai "$SAM_REPO_DIR"
+fi
+
+# Install SAMURAI in editable mode with notebooks extras
+pip install -e "$SAM_REPO_DIR"
+pip install -e "$SAM_REPO_DIR"\[notebooks\]
+
+# Download checkpoints
+bash "$SAM_REPO_DIR/checkpoints/download_ckpts.sh"
+
+# Copy chosen checkpoint to top-level checkpoints directory
+CKPT_NAME="${1:-sam2.1_hiera_large.pt}"
+mkdir -p "$ROOT_DIR/checkpoints"
+cp "$SAM_REPO_DIR/checkpoints/$CKPT_NAME" "$ROOT_DIR/checkpoints/"
+
+echo "Checkpoint copied to $ROOT_DIR/checkpoints/$CKPT_NAME"


### PR DESCRIPTION
## Summary
- add `sam2/setup_samurai.sh` to automate SAMURAI installation and checkpoint handling

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_688505f5483c8327a5e7b926f6100940